### PR TITLE
Fixed branch select and added Makefile to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ C++ Competitive Programming tips to **improve your thinking speed**, making your
 If you have to do lots of exercise and rewrite every single template, you don't need to do this anymore. With our templates, you can fill a folder with usefull files, perfect for your job.
 
 ### Filling folder with `.cpp`, `.txt` and `Makefile` :mag_right:
-Open the `terminal` and type for, **current** version (**main** branch)
+Open the `terminal` and type:
+
+**Current** version (**Main** branch)
 ```
 bash <(curl -sL bash.propi.dev/cp)
 ```
-**upcoming** version (**develop** branch)
+**Upcoming** version (**Develop** branch)
 ```
-bash <(curl -sL bash.propi.dev/upcoming/cp)
+bash <(curl -sL bash.propi.dev/cp) up
 ```
 
 ![cp-tips](https://github.com/propilideno/Competitive-Programming-Tips/assets/105776775/ed7a636c-f4dd-4849-8e4f-6fa2e2bc5379)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ bash <(curl -sL bash.propi.dev/cp)
 ```
 **Upcoming** version (**Develop** branch)
 ```
-bash <(curl -sL bash.propi.dev/cp) up
+bash <(curl -sL bash.propi.dev/upcoming/cp) up
 ```
 
 ![cp-tips](https://github.com/propilideno/Competitive-Programming-Tips/assets/105776775/ed7a636c-f4dd-4849-8e4f-6fa2e2bc5379)

--- a/buildLab.sh
+++ b/buildLab.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 
-solutionTemplate=$(curl -s https://raw.githubusercontent.com/propilideno/Competitive-Programming-Tips/develop/templates/cpp/basic.cpp)
-makefileTemplate='run-%:\n\tg++ $*.cpp\n\t./a.out < input/$*.txt\n\ndebug-%:\n\tg++ -g $*.cpp\n\tgdb -ex "run < input/$*.txt" ./a.out'
+function selectBranch(){
+	branch="main" #Default Branch
+	if [[ $# != 0 ]]; then
+		if [[ $1 != "$branch" && "$1" == "up" ]]; then
+			branch="develop"
+		else
+			exit_failure "'$1' is not a valid choice!"
+		fi
+	fi
+}
+
+function settings(){
+	selectBranch $1
+	solutionTemplate=$(curl -s https://raw.githubusercontent.com/propilideno/Competitive-Programming-Tips/$branch/templates/cpp/basic.cpp)
+	makefileTemplate='run-%:\n\tg++ $*.cpp\n\t./a.out < input/$*.txt\n\ndebug-%:\n\tg++ -g $*.cpp\n\tgdb -ex "run < input/$*.txt" ./a.out'
+}
 
 function chr() {
 	local ascii_Value=$(awk -v v="$1" 'BEGIN{printf "%c", v}')
@@ -22,6 +36,14 @@ function createFiles(){
     done
 }
 
+function exit_failure(){
+	echo "Something got wrong! Check our current documentation in: https://propi.dev/cp"
+	if [[ $# != 0 ]]; then
+		echo "<ERROR> $1"
+	fi
+	exit 1
+}
+
 function greetings(){
     printf "\n==> All files was created with SUCCESS !!!\n"
     echo "==> Contribute with us giving this repo a Star ⭐"
@@ -33,8 +55,9 @@ function greetings(){
 }
 
 function main(){
+	settings $1
 	createFiles
 	greetings
 }
 
-main
+main $1

--- a/buildLab.sh
+++ b/buildLab.sh
@@ -26,7 +26,7 @@ function greetings(){
     printf "\n==> All files was created with SUCCESS !!!\n"
     echo "==> Contribute with us giving this repo a Star ⭐"
     echo "Maintainers:"
-    printf "\t - Lucas R. de Almeida       | @propilideno\n"
+    printf "\t - Lucas R. de Almeida       | hello@propi.dev\n"
 	echo "Honorable Mentions:"
     printf "\t - Giovanni V. Comarela      | gc@inf.ufes.br\n"
     exit 1

--- a/buildLab.sh
+++ b/buildLab.sh
@@ -14,7 +14,7 @@ function selectBranch(){
 function settings(){
 	selectBranch $1
 	solutionTemplate=$(curl -s https://raw.githubusercontent.com/propilideno/Competitive-Programming-Tips/$branch/templates/cpp/basic.cpp)
-	makefileTemplate='run-%:\n\tg++ $*.cpp\n\t./a.out < input/$*.txt\n\ndebug-%:\n\tg++ -g $*.cpp\n\tgdb -ex "run < input/$*.txt" ./a.out'
+	makefileTemplate=$(curl -s https://raw.githubusercontent.com/propilideno/Competitive-Programming-Tips/$branch/templates/cpp/Makefile)
 }
 
 function chr() {

--- a/templates/cpp/Makefile
+++ b/templates/cpp/Makefile
@@ -1,0 +1,7 @@
+run-%:
+	g++ $*.cpp
+	./a.out < input/$*.txt
+
+debug-%:
+	g++ -g $*.cpp
+	gdb -ex "run < input/$*.txt" ./a.out


### PR DESCRIPTION
## Changes made
-  `buildLab.sh` now can receive input `up` to select develop branch templates.
- `Makefile` was added to templates folder to provide more flexible changes
- Now we're using curl to select Makefile too.

## Bug fixes
- `buildLab.sh` was not able to select main templates, so it was fixed in this PR.

## Issues fixed
- #3 